### PR TITLE
Fix the way the media URL is constructed, to reflect recent changes on the website

### DIFF
--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -129,7 +129,7 @@ class Programs:
         for media in soup.findAll('div', {'class': 'contenu-descr-8 '}):
             tag = media.findPrevious('a')
             # Get link, title and thumb
-            media_link = URLASI + tag['href']
+            media_link = tag['href']
             media_title = tag['title'].encode('utf-8')
             media_thumb = URLASI + tag.find('img', attrs={'src': re.compile('.+?\.[png|jpg]')})['src']
             yield {'url': media_link, 'title': media_title, 'thumb': media_thumb}


### PR DESCRIPTION
It does not seem necessary any more to prefix the href found in the HTML with the ASI URL. This prefix is already in the href

This fixed the videos for me
