### PR TITLE
remplacer "utilisateur" par "e-mail @si"

### DIFF
--- a/resources/language/French/strings.xml
+++ b/resources/language/French/strings.xml
@@ -18,13 +18,13 @@
 
     <!--Errors-->
     <string id="30050">Erreur de connexion</string>
-    <string id="30051">Saisissez votre nom d'utilisateur et mot de passe</string>
+    <string id="30051">Saisissez votre nom d'utilisateur (e-mail) et mot de passe</string>
     <string id="30052">dans les paramètres de l'add-on</string>
     <string id="30053">Utilisateur / mot de passe incorrect</string>
 
     <!--Settings-->
     <string id="30070">Compte</string>
-    <string id="30071">utilisateur</string>
+    <string id="30071">e-mail utilisé pour @si</string>
     <string id="30072">mot de passe</string>
     <string id="30080">Affichage</string>
     <string id="30081">Afficher</string>


### PR DESCRIPTION
D'autres auront peut-être le même problème pour s'identifier : il faut entrer comme nom d'utilisateur « l’e-mail que vous utilisez pour @si » (c'est la formulation exacte du site) et non son pseudo. Le préciser simplifierait la vie des gens utilisant l'add-on, même si ça utilise plus de caractères.
